### PR TITLE
Add new method to support segmentation on multiple properties

### DIFF
--- a/src/mixpanel_data_export.js
+++ b/src/mixpanel_data_export.js
@@ -92,6 +92,10 @@ var MixpanelExport = (function() {
     return this.get(["segmentation", "average"], parameters, callback);
   };
 
+  MixpanelExport.prototype.multiSegmentation = function(parameters, callback) {
+    return this.get(["segmentation", "mulitseg"], parameters, callback);
+  };
+
   MixpanelExport.prototype.retention = function(parameters, callback) {
     return this.get(["retention"], parameters, callback);
   };


### PR DESCRIPTION
# Why?
Support the segmentation/multiseg API which allows to segment on two properties instead of a single one.

# Extra
This is not officially documented by mixpanel, but if you inspect their network request in their web app, you will notice the following request with `multiseg`

```
https://mixpanel.com/api/2.0/segmentation/multiseg?inner=properties%5B%22property1%22%5D&outer=properties%5B%22property2%22%5D
```

where 
 `inner` is the first property you want to segment and
 `outer` is the segmentation on the inner property.

Note that it was already implemented by other libraries
http://libsaas.readthedocs.org/en/latest/generated/mixpanel/