### PR TITLE
Trap errors from the export endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 sandbox.js
 index.html
 npm-debug.log
+.DS_Store


### PR DESCRIPTION
Mixpanel's non-export API endpoints give 200 status codes with a JSON error when something goes wrong, but the export endpoint gives a non-200 status code with a string. The library was trying to parse this into JSON, failing awkwardly and blowing up.

This isn't really a full fix, as ideally we'd have promises rejecting properly with errors when they occur, but it should at least make the export API's behaviour consistent with behaviour of the other methods and give a similarly structured `{ error: "foobar" }` object